### PR TITLE
Integrate journal entry with profit tracker and calendar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -45603,6 +45603,20 @@ body {
     white-space: nowrap;
 }
 
+/* Billing status badges on calendar */
+.status-badge {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 2px 6px;
+    border-radius: 8px;
+    font-size: 10px;
+    font-weight: 600;
+    color: #fff;
+}
+.status-badge.unbilled { background: #ff9800; }
+.status-badge.invoiced { background: #2196f3; }
+.status-badge.paid { background: #4caf50; }
+
 /* Tab Interface Styles */
 .tracker-tabs {
     display: flex;


### PR DESCRIPTION
Integrate journal entries with the calendar and profit tracker to visualize hours, billing status, and forecast revenue.

This PR fulfills the user's request to connect journal entries to the calendar and profit tracker, enabling a comprehensive view of logged time. It introduces billing status tracking for journaled hours, displaying this status on the calendar and reflecting forecast revenue and labor costs in the profit tracker.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fb6a8ae-423e-44a4-b5a8-1277dbc2f729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8fb6a8ae-423e-44a4-b5a8-1277dbc2f729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

